### PR TITLE
Replicator support

### DIFF
--- a/ft.fieldtamer.php
+++ b/ft.fieldtamer.php
@@ -47,7 +47,7 @@ class Fieldtype_fieldtamer extends Fieldtype
 					var fieldSelector = (val === "content")
 					                    ? "[name=\'page[content]\']"
 					                    : "[name^=\'page[yaml]["+val+"]\'], [data-empty-row*=\'page[yaml]["+val+"]\'], [data-field-name*=\'page[yaml]["+val+"]\']";
-					var inputRow = fieldContainer.find(fieldSelector).first().closest(".input-block");
+					var inputRow = fieldContainer.find(fieldSelector).first().parents(".input-block").last();
 					inputRow.appendTo("#'.$placeholder.'");
 				});
 

--- a/ft.fieldtamer.php
+++ b/ft.fieldtamer.php
@@ -46,7 +46,7 @@ class Fieldtype_fieldtamer extends Fieldtype
 				$(fields).each(function(key, val) {
 					var fieldSelector = (val === "content")
 					                    ? "[name=\'page[content]\']"
-					                    : "[name^=\'page[yaml]["+val+"]\'], [data-empty-row*=\'page[yaml]["+val+"]\'], [data-field-name*=\'page[yaml]["+val+"]\']";
+					                    : "[name^=\'page[yaml]["+val+"]\'], [data-empty-row*=\'page[yaml]["+val+"]\']";
 					var inputRow = fieldContainer.find(fieldSelector).first().parents(".input-block").last();
 					inputRow.appendTo("#'.$placeholder.'");
 				});


### PR DESCRIPTION
The previous Replicator support commit didn't grab and move Replicators properly.

The problem was that `.closest()` was grabbing the first parent with the `input-block` class. It should've grabbed the last ancestor with the class instead.
